### PR TITLE
DELIA-67277: Use the updated msg_unpack_next() for handling webconfig data 

### DIFF
--- a/src/rrdMsgPackDecoder.c
+++ b/src/rrdMsgPackDecoder.c
@@ -175,15 +175,14 @@ void *helper_convert(const void *buf, size_t len,
 msgpack_unpack_return get_msgpack_unpack_status(char *decodedbuf, int size)
 {
 
-    msgpack_zone mempool;
-    msgpack_object deserialized;
+    msgpack_unpacked deserialized;
+    msgpack_unpacked_init(&deserialized);
     msgpack_unpack_return unpack_ret;
 
     if (decodedbuf == NULL || !size)
         return MSGPACK_UNPACK_NOMEM_ERROR;
 
-    msgpack_zone_init(&mempool, 2048);
-    unpack_ret = msgpack_unpack(decodedbuf, size, NULL, &mempool, &deserialized);
+    unpack_ret = msgpack_unpack_next(&deserialized, decodedbuf, size, NULL);
 
         switch(unpack_ret)
         {
@@ -206,7 +205,7 @@ msgpack_unpack_return get_msgpack_unpack_status(char *decodedbuf, int size)
                 RDK_LOG(RDK_LOG_DEBUG, LOG_REMDEBUG, "[%s:%d]: Message Pack decode failed with error\n", __FUNCTION__, __LINE__);
         }
     
-    msgpack_zone_destroy(&mempool);
+    msgpack_unpacked_destroy( &deserialized );
     // End of msgpack decoding
 
     return unpack_ret;

--- a/src/unittest/rrdUnitTestRunner.cpp
+++ b/src/unittest/rrdUnitTestRunner.cpp
@@ -2951,7 +2951,8 @@ TEST(GetMsgpackUnpackStatusTest, MsgpackUnpackReturnsExtraBytes)
     msgpack_pack_int(&pk, 1);
     sbuf.data[sbuf.size] = '\0'; // Add an extra byte
 
-    EXPECT_EQ(get_msgpack_unpack_status(sbuf.data, sbuf.size + 1), MSGPACK_UNPACK_EXTRA_BYTES);
+    // msg_unpack_next() internally handles EXTRABYTES. It should return SUCCESS.
+    EXPECT_EQ(get_msgpack_unpack_status(sbuf.data, sbuf.size + 1), MSGPACK_UNPACK_SUCCESS);
 
     msgpack_sbuffer_destroy(&sbuf);
 }


### PR DESCRIPTION
Reason for change: Use updated function to handle webconfig data
Test Procedure: Build RDKE image

Signed-off-by: [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)