### PR TITLE
RDKEMW-1768 -Fix UT in RRD with Static profile update and Null Check

### DIFF
--- a/src/rrdCommandSanity.c
+++ b/src/rrdCommandSanity.c
@@ -18,6 +18,7 @@
 */
 
 #include "rrdCommandSanity.h"
+#include <ctype.h>
 
 /*
  * @function updateBackgroundCmd
@@ -131,9 +132,21 @@ int isCommandsValid(char *issuecmd,cJSON *sanitylist)
     {
          subcmd = cJSON_GetArrayItem(sanitylist, i);
          checkcmd = cJSON_Print(subcmd); // Print each command from the sanity command array in Json
+         int len = strlen(checkcmd);
+         if (len >= 2 && checkcmd[0] == '"' && checkcmd[len - 1] == '"') 
+         {
+             checkcmd[len - 1] = '\0'; // Remove closing quote
+             checkcmd++;               // Move pointer forward to skip opening quote
+             len -= 2;            // Adjust length after removing quotes
+         }
+         // Trim trailing spaces
+         int j = len - 1;
+         while (j >= 0 && isspace(checkcmd[j])) {
+         checkcmd[j] = '\0';
+         j--;
+         }
          RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]: Checking for \"%s\" string in Issue commands... \n",__FUNCTION__,__LINE__,checkcmd);
          sanitystr = strstr(issuecmd,checkcmd);
-         cJSON_free(checkcmd); // free each command from the sanity command array
          if (sanitystr)
          {
              RDK_LOG(RDK_LOG_ERROR,LOG_REMDEBUG,"[%s:%d]: Found harmful commands: %s, Exiting!!! \n",__FUNCTION__,__LINE__,sanitystr);

--- a/src/rrdEventProcess.c
+++ b/src/rrdEventProcess.c
@@ -322,7 +322,11 @@ issueData* processIssueTypeInDynamicProfileappend(data_buf *rbuf, issueNodeData 
 
     RDK_LOG(RDK_LOG_DEBUG, LOG_REMDEBUG, "[%s:%d]: ...Entering.. \n", __FUNCTION__, __LINE__);
     rrdjsonlen = strlen(RRD_JSON_FILE);
+#ifdef IARMBUS_SUPPORT
     persistentAppslen = strlen(RRD_MEDIA_APPS);
+#else
+    persistentAppslen = strlen(RRD_TMP_DIR);
+#endif
     prefixlen = strlen(RDM_PKG_PREFIX);
     dynJSONPath = (char *)malloc(persistentAppslen + prefixlen + strlen(pIssueNode->Node) + rrdjsonlen + 1);
 
@@ -331,8 +335,11 @@ issueData* processIssueTypeInDynamicProfileappend(data_buf *rbuf, issueNodeData 
         RDK_LOG(RDK_LOG_DEBUG, LOG_REMDEBUG, "[%s:%d]: Memory Allocation Failed... \n", __FUNCTION__, __LINE__);
         return dynamicdata;
     }
+#ifdef IARMBUS_SUPPORT
     sprintf(dynJSONPath, "%s%s%s%s", RRD_MEDIA_APPS, RDM_PKG_PREFIX, pIssueNode->Node, RRD_JSON_FILE);
-
+#else	
+    sprintf(dynJSONPath, "%s%s%s%s", RRD_TMP_DIR, RDM_PKG_PREFIX, pIssueNode->Node, RRD_JSON_FILE);
+#endif
     RDK_LOG(RDK_LOG_INFO, LOG_REMDEBUG, "[%s:%d]: Checking Dynamic Profile... \n", __FUNCTION__, __LINE__);
     jsonParsed = readAndParseJSON(dynJSONPath);
     if (jsonParsed == NULL)
@@ -427,7 +434,7 @@ static void processIssueTypeInInstalledPackage(data_buf *rbuf, issueNodeData *pI
     rrdjsonlen = strlen(RRD_JSON_FILE);
 #ifdef IARMBUS_SUPPORT
     persistentAppslen = strlen(RRD_MEDIA_APPS);
-else
+#else
     persistentAppslen = strlen(RRD_TMP_DIR);
 #endif
     prefixlen = strlen(RDM_PKG_PREFIX);

--- a/src/rrdEventProcess.c
+++ b/src/rrdEventProcess.c
@@ -22,6 +22,7 @@
 #include "rrdEventProcess.h"
 
 #define COMMAND_DELIM ';'
+#define RRD_TMP_DIR "/tmp/"
 
 static void processIssueType(data_buf *rbuf);
 static void processIssueTypeInDynamicProfile(data_buf *rbuf, issueNodeData *pIssueNode);
@@ -424,7 +425,11 @@ static void processIssueTypeInInstalledPackage(data_buf *rbuf, issueNodeData *pI
     RDK_LOG(RDK_LOG_DEBUG, LOG_REMDEBUG, "[%s:%d]: ...Entering.. \n", __FUNCTION__, __LINE__);
 #if !defined(GTEST_ENABLE)
     rrdjsonlen = strlen(RRD_JSON_FILE);
+#ifdef IARMBUS_SUPPORT
     persistentAppslen = strlen(RRD_MEDIA_APPS);
+else
+    persistentAppslen = strlen(RRD_TMP_DIR);
+#endif
     prefixlen = strlen(RDM_PKG_PREFIX);
     suffixlen = strlen(RDM_PKG_SUFFIX);
     dynJSONPath = (char *)malloc(persistentAppslen + prefixlen + suffixlen + strlen(pIssueNode->Node) + rrdjsonlen + 1);
@@ -439,7 +444,11 @@ static void processIssueTypeInInstalledPackage(data_buf *rbuf, issueNodeData *pI
         return;
     }
 #if !defined(GTEST_ENABLE)
+#ifdef IARMBUS_SUPPORT
     sprintf(dynJSONPath, "%s%s%s%s", RRD_MEDIA_APPS, RDM_PKG_PREFIX, pIssueNode->Node, RRD_JSON_FILE);
+#else
+    sprintf(dynJSONPath, "%s%s%s%s", RRD_TMP_DIR, RDM_PKG_PREFIX, pIssueNode->Node, RRD_JSON_FILE);
+#endif
 #else
     sprintf(dynJSONPath, "%s", rbuf->jsonPath);
 #endif

--- a/src/rrdInterface.c
+++ b/src/rrdInterface.c
@@ -222,7 +222,12 @@ void _rdmDownloadEventHandler(rbusHandle_t handle, rbusEvent_t const* event, rbu
 	 return;
     }	
     RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]: issue type_value: = [%s]\n", __FUNCTION__, __LINE__, rbusValue_GetString(value, NULL));
-    issue =rbusValue_GetString(value, NULL);	
+    issue =rbusValue_GetString(value, NULL);
+    char *dot_position = strchr(issue, '.'); // Find the first occurrence of '.'
+    if (dot_position != NULL) 
+    {
+        *dot_position = '\0'; // Replace '.' with null terminator
+    }
     size_t len = strlen(RDM_PKG_PREFIX) + strlen(issue) + 1;
 
     char *pkg_name = (char *)malloc(len);

--- a/src/rrdJsonParser.c
+++ b/src/rrdJsonParser.c
@@ -430,6 +430,15 @@ bool invokeSanityandCommandExec(issueNodeData *issuestructNode, cJSON *jsoncfg, 
         check = cJSON_GetObjectItem(sanity, "Check");
         checkval = cJSON_Print(check);  // Print list of sanity commands received
         RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]: Reading Sanity Check Commands List: \n%s\n",__FUNCTION__,__LINE__,checkval);
+	if(checkval ==NULL)
+	{
+	    RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]: Entering checkval null case : \n",__FUNCTION__,__LINE__);
+            jsoncfg = readAndParseJSON(RRD_JSON_FILE);
+	    sanity = cJSON_GetObjectItem(jsoncfg, "Sanity");
+	    check = cJSON_GetObjectItem(sanity, "Check");
+            checkval = cJSON_Print(check);  // Print list of sanity commands received
+            RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]: Reading Sanity Check Commands List: \n%s\n",__FUNCTION__,__LINE__,checkval);
+        }
         cmdlist = cJSON_GetObjectItem(check, "Commands");
         cJSON_free(checkval); // free sanity command list
         ret = isCommandsValid(issuestdata->command, cmdlist);


### PR DESCRIPTION
Reason for change: Fix UT in RRD with Static profile update and Null Check
Test Procedure: Basic Sanity, Ensure sanity check is working in static, Dynamic profiles
Risks: Low
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)