### PR TITLE
RDKEMW-3380 : Evaluate the Deepsleep Scenario for Static and Dynamic method

### DIFF
--- a/src/rrdIarmEvents.c
+++ b/src/rrdIarmEvents.c
@@ -245,7 +245,6 @@ void _pwrManagerEventHandler(const char *owner, IARM_EventId_t eventId, void *da
             }
             strncpy((char *)sbuf->mdata, (const char *)DEEP_SLEEP_STR, msgLen);
             RRDMsgDeliver(msqid, sbuf);
-	    RRD_data_buff_deAlloc(sbuf);
         }
         else
         {


### PR DESCRIPTION
Reason for change: Fix operational gaps in deepsleep scenario in rrd
Test Procedure: Focused Regression over remotedebugger
Risks: Medium
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)