### PR TITLE
DELIA-68122 - RRD device stopped running RRD commands, logs show no progress

### DIFF
--- a/src/rrdInterface.c
+++ b/src/rrdInterface.c
@@ -318,13 +318,15 @@ void _remoteDebuggerEventHandler(rbusHandle_t handle, rbusEvent_t const* event, 
         return;
     }
 
-    int len = strlen(rbusValue_GetString(value, NULL));
-    dataMsg = (char*) rbusValue_GetString(value, NULL);
+    int len = strlen(rbusValue_GetString(value, NULL))+1;
+    dataMsg = (char *) calloc(1, len);
     if(!dataMsg)
     {
-        RDK_LOG(RDK_LOG_ERROR,LOG_REMDEBUG,"[%s:%d]: Returning dataMsg being NULL \n", __FUNCTION__, __LINE__);
+        RDK_LOG(RDK_LOG_ERROR,LOG_REMDEBUG,"[%s:%d]: Memory Allocation Failed for %s \n", __FUNCTION__, __LINE__, rbusValue_ToString(value, NULL, 0));
         return;
     }
+    strncpy(dataMsg, rbusValue_GetString(value, NULL), len-1);
+    dataMsg[len-1]='\0';
     if (dataMsg[0] == '\0' || len <= 0  )
     {
         RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]: Message Received is empty, Exit Processing!!! \n", __FUNCTION__, __LINE__);


### PR DESCRIPTION
Reason for change: RRD failing in device for some commands, getting invalid message type (SCXI11BEI)
Test Procedure: Focussed regression on remote debugger static profile
Risks: Low
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)