### PR TITLE
DELIA-68569 - WebPA Query fails for RRD Enabled command

### DIFF
--- a/src/rrdMain.c
+++ b/src/rrdMain.c
@@ -93,10 +93,24 @@ bool isRRDEnabled(void)
     RFC_ParamData_t param;
     WDMP_STATUS status = getRFCParameter("RDKRemoteDebugger", RRD_RFC, &param);
     if(status == WDMP_SUCCESS || status == WDMP_ERR_DEFAULT_VALUE) {
+        const char *filePath = "/tmp/rrd_enabled";
+        FILE *fp = fopen(filePath, "w");
 	    RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]:getRFCParameter() name=%s,type=%d,value=%s\n", __FUNCTION__, __LINE__, param.name, param.type, param.value);
+		if (fp) {
+            fprintf(fp, "%s\n", param.value);  // Write the RFC parameter value
+            fclose(fp);
+            RDK_LOG(RDK_LOG_INFO, LOG_REMDEBUG, "[%s:%d]: Wrote '%s' to file %s\n", __FUNCTION__, __LINE__, param.value, filePath);
+        } 
+		else {
+            RDK_LOG(RDK_LOG_ERROR, LOG_REMDEBUG, "[%s:%d]: Failed to open file %s for writing\n", __FUNCTION__, __LINE__, filePath);
+        }
 	    if (strcasecmp("false", param.value) == 0) {
+			
 		    ret = false;
 	    }
+
+
+		
 	    /*
 	    else {
 	            const char *filePath = "/tmp/rrd_enabled";
@@ -158,15 +172,6 @@ int main(int argc, char *argv[])
 #endif
     /* Initialize Cache */
     initCache();
-    const char *filePath = "/tmp/rrd_enabled";
-    FILE *fp = fopen(filePath, "w");
-    if (fp) {
-        fclose(fp);
-        RDK_LOG(RDK_LOG_INFO, LOG_REMDEBUG, "[%s:%d]:RRD is enabled, touched file %s\n", __FUNCTION__, __LINE__, filePath);
-    }
-    else {
-        RDK_LOG(RDK_LOG_ERROR, LOG_REMDEBUG, "[%s:%d]:Failed to touch file %s\n", __FUNCTION__, __LINE__, filePath);
-    }
     /* Check RRD Enable RFC */
     bool isEnabled = isRRDEnabled();
     if(!isEnabled) {

--- a/src/rrdMain.c
+++ b/src/rrdMain.c
@@ -99,7 +99,7 @@ bool isRRDEnabled(void)
 	    }
 	    else {
 	            const char *filePath = "/tmp/rrd_enabled";
-                    ILE *fp = fopen(filePath, "w");
+                    FILE *fp = fopen(filePath, "w");
                     if (fp) {
                         fclose(fp);
                         RDK_LOG(RDK_LOG_INFO, LOG_REMDEBUG, "[%s:%d]:RRD is enabled, touched file %s\n", __FUNCTION__, __LINE__, filePath);
@@ -107,6 +107,7 @@ bool isRRDEnabled(void)
 		    else {
                         RDK_LOG(RDK_LOG_ERROR, LOG_REMDEBUG, "[%s:%d]:Failed to touch file %s\n", __FUNCTION__, __LINE__, filePath);
                     }
+	    }
     } 
     else {
 	RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]:ERROR in getRFCParameter()\n", __FUNCTION__, __LINE__);

--- a/src/rrdMain.c
+++ b/src/rrdMain.c
@@ -108,22 +108,6 @@ bool isRRDEnabled(void)
 			
 		    ret = false;
 	    }
-
-
-		
-	    /*
-	    else {
-	            const char *filePath = "/tmp/rrd_enabled";
-                    FILE *fp = fopen(filePath, "w");
-                    if (fp) {
-                        fclose(fp);
-                        RDK_LOG(RDK_LOG_INFO, LOG_REMDEBUG, "[%s:%d]:RRD is enabled, touched file %s\n", __FUNCTION__, __LINE__, filePath);
-                    }
-		    else {
-                        RDK_LOG(RDK_LOG_ERROR, LOG_REMDEBUG, "[%s:%d]:Failed to touch file %s\n", __FUNCTION__, __LINE__, filePath);
-                    }
-	    }
-            */
     } 
     else {
 	RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]:ERROR in getRFCParameter()\n", __FUNCTION__, __LINE__);

--- a/src/rrdMain.c
+++ b/src/rrdMain.c
@@ -97,6 +97,16 @@ bool isRRDEnabled(void)
 	    if (strcasecmp("false", param.value) == 0) {
 		    ret = false;
 	    }
+	    else {
+	            const char *filePath = "/tmp/rrd_enabled";
+                    ILE *fp = fopen(filePath, "w");
+                    if (fp) {
+                        fclose(fp);
+                        RDK_LOG(RDK_LOG_INFO, LOG_REMDEBUG, "[%s:%d]:RRD is enabled, touched file %s\n", __FUNCTION__, __LINE__, filePath);
+                    }
+		    else {
+                        RDK_LOG(RDK_LOG_ERROR, LOG_REMDEBUG, "[%s:%d]:Failed to touch file %s\n", __FUNCTION__, __LINE__, filePath);
+                    }
     } 
     else {
 	RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]:ERROR in getRFCParameter()\n", __FUNCTION__, __LINE__);

--- a/src/rrdMain.c
+++ b/src/rrdMain.c
@@ -158,16 +158,6 @@ int main(int argc, char *argv[])
 #endif
     /* Initialize Cache */
     initCache();
-
-    /* Check RRD Enable RFC */
-    bool isEnabled = isRRDEnabled();
-    if(!isEnabled) {
-        RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]:RFC is disabled, stopping remote-debugger\n", __FUNCTION__, __LINE__);
-        exit(0);
-    }
-    
-    RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]:Starting RDK Remote Debugger Daemon \n",__FUNCTION__,__LINE__);
-
     const char *filePath = "/tmp/rrd_enabled";
     FILE *fp = fopen(filePath, "w");
     if (fp) {
@@ -177,6 +167,15 @@ int main(int argc, char *argv[])
     else {
         RDK_LOG(RDK_LOG_ERROR, LOG_REMDEBUG, "[%s:%d]:Failed to touch file %s\n", __FUNCTION__, __LINE__, filePath);
     }
+    /* Check RRD Enable RFC */
+    bool isEnabled = isRRDEnabled();
+    if(!isEnabled) {
+        RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]:RFC is disabled, stopping remote-debugger\n", __FUNCTION__, __LINE__);
+        exit(0);
+    }
+    
+    RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]:Starting RDK Remote Debugger Daemon \n",__FUNCTION__,__LINE__);
+
     if ((msqid = msgget(key, IPC_CREAT | 0666 )) < 0)
     {
         RDK_LOG(RDK_LOG_ERROR,LOG_REMDEBUG,"[%s:%d]:Message Queue ID Creation failed, msqid=%d!!!\n",__FUNCTION__,__LINE__,msqid);

--- a/src/rrdMain.c
+++ b/src/rrdMain.c
@@ -97,6 +97,7 @@ bool isRRDEnabled(void)
 	    if (strcasecmp("false", param.value) == 0) {
 		    ret = false;
 	    }
+	    /*
 	    else {
 	            const char *filePath = "/tmp/rrd_enabled";
                     FILE *fp = fopen(filePath, "w");
@@ -108,6 +109,7 @@ bool isRRDEnabled(void)
                         RDK_LOG(RDK_LOG_ERROR, LOG_REMDEBUG, "[%s:%d]:Failed to touch file %s\n", __FUNCTION__, __LINE__, filePath);
                     }
 	    }
+            */
     } 
     else {
 	RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]:ERROR in getRFCParameter()\n", __FUNCTION__, __LINE__);
@@ -165,6 +167,16 @@ int main(int argc, char *argv[])
     }
     
     RDK_LOG(RDK_LOG_DEBUG,LOG_REMDEBUG,"[%s:%d]:Starting RDK Remote Debugger Daemon \n",__FUNCTION__,__LINE__);
+
+    const char *filePath = "/tmp/rrd_enabled";
+    FILE *fp = fopen(filePath, "w");
+    if (fp) {
+        fclose(fp);
+        RDK_LOG(RDK_LOG_INFO, LOG_REMDEBUG, "[%s:%d]:RRD is enabled, touched file %s\n", __FUNCTION__, __LINE__, filePath);
+    }
+    else {
+        RDK_LOG(RDK_LOG_ERROR, LOG_REMDEBUG, "[%s:%d]:Failed to touch file %s\n", __FUNCTION__, __LINE__, filePath);
+    }
     if ((msqid = msgget(key, IPC_CREAT | 0666 )) < 0)
     {
         RDK_LOG(RDK_LOG_ERROR,LOG_REMDEBUG,"[%s:%d]:Message Queue ID Creation failed, msqid=%d!!!\n",__FUNCTION__,__LINE__,msqid);

--- a/src/rrdMain.c
+++ b/src/rrdMain.c
@@ -99,10 +99,10 @@ bool isRRDEnabled(void)
 		if (fp) {
             fprintf(fp, "%s\n", param.value);  // Write the RFC parameter value
             fclose(fp);
-            RDK_LOG(RDK_LOG_INFO, LOG_REMDEBUG, "[%s:%d]: Wrote '%s' to file %s\n", __FUNCTION__, __LINE__, param.value, filePath);
+            RDK_LOG(RDK_LOG_DEBUG, LOG_REMDEBUG, "[%s:%d]: Wrote '%s' to file %s\n", __FUNCTION__, __LINE__, param.value, filePath);
         } 
 		else {
-            RDK_LOG(RDK_LOG_ERROR, LOG_REMDEBUG, "[%s:%d]: Failed to open file %s for writing\n", __FUNCTION__, __LINE__, filePath);
+            RDK_LOG(RDK_LOG_DEBUG, LOG_REMDEBUG, "[%s:%d]: Failed to open file %s for writing\n", __FUNCTION__, __LINE__, filePath);
         }
 	    if (strcasecmp("false", param.value) == 0) {
 			


### PR DESCRIPTION
Reason for change: WebPA Query fails for RRD Enabled command
Test Procedure: Focused Regression
Risks: Low
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)